### PR TITLE
fix for error when adding a new group menu

### DIFF
--- a/src/Form/GroupMenuFormStep2.php
+++ b/src/Form/GroupMenuFormStep2.php
@@ -30,7 +30,7 @@ class GroupMenuFormStep2 extends GroupContentForm {
    *   The factory for the temp store object.
    */
   public function __construct(EntityManagerInterface $entity_manager, PrivateTempStoreFactory $temp_store_factory) {
-    parent::__construct($entity_manager);
+    parent::__construct($temp_store_factory, $entity_manager);
     $this->privateTempStore = $temp_store_factory->get('group_menu_add_temp');
   }
 


### PR DESCRIPTION
TypeError: Argument 1 passed to Drupal\group\Entity\Form\GroupContentForm::__construct() must be an instance of Drupal\user\PrivateTempStoreFactory, instance of Drupal\Core\Entity\EntityManager given, called in /vagrant/drupal/current/web/modules/contrib/groupmenu/src/Form/GroupMenuFormStep2.php on line 33

Occurs when trying to add a new group menu.