### PR TITLE
Move $route_params up in scope;  was not available in the second if block

### DIFF
--- a/src/Plugin/GroupContentEnabler/GroupMenu.php
+++ b/src/Plugin/GroupContentEnabler/GroupMenu.php
@@ -28,9 +28,9 @@ class GroupMenu extends GroupContentEnablerBase {
   public function getGroupOperations(GroupInterface $group) {
     $account = \Drupal::currentUser();
     $operations = [];
+    $route_params = ['group' => $group->id()];
 
     if ($group->hasPermission("create group menus", $account)) {
-      $route_params = ['group' => $group->id()];
       $operations["group-menu-create-menu"] = [
         'title' => $this->t('Create menu'),
         'url' => new Url('entity.group_menu.group_menu_add_form', $route_params),


### PR DESCRIPTION
Fixes:

TypeError: Argument 3 passed to Drupal\\Core\\Routing\\UrlGenerator::processRoute() must be of the type array, null given, called in /Library/WebServer/Documents/workspace/UNL-CMS-2/core/lib/Drupal/Core/Routing/UrlGenerator.php on line 123 in /Library/WebServer/Documents/workspace/UNL-CMS-2/core/lib/Drupal/Core/Routing/UrlGenerator.php on line 403