### PR TITLE
8.3 Compatibility: Remove $entity_query_factory param from MenuForm

### DIFF
--- a/group_menu.info.yml
+++ b/group_menu.info.yml
@@ -2,7 +2,7 @@ name: Group Menu
 type: module
 description: Gives the ability to create and manage menus for groups
 package: Group
-core: 8.x
+core: 8.3.x
 dependencies:
  - group
  - menu_ui

--- a/src/Form/GroupMenuFormStep1.php
+++ b/src/Form/GroupMenuFormStep1.php
@@ -27,14 +27,17 @@ class GroupMenuFormStep1 extends MenuForm {
   /**
    * Constructs a GroupNodeFormStep1 object.
    *
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager.
+   * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menu_link_manager
+   *   The menu link manager.
+   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree
+   *   The menu tree service.
+   * @param \Drupal\Core\Utility\LinkGeneratorInterface $link_generator
+   *   The link generator.
    * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
    *   The factory for the temp store object.
    */
-  public function __construct(QueryFactory $entity_query_factory, MenuLinkManagerInterface $menu_link_manager,
-MenuLinkTreeInterface $menu_tree, LinkGeneratorInterface $link_generator, PrivateTempStoreFactory $temp_store_factory) {
-    parent::__construct($entity_query_factory, $menu_link_manager, $menu_tree, $link_generator);
+  public function __construct(MenuLinkManagerInterface $menu_link_manager, MenuLinkTreeInterface $menu_tree, LinkGeneratorInterface $link_generator, PrivateTempStoreFactory $temp_store_factory) {
+    parent::__construct($menu_link_manager, $menu_tree, $link_generator);
     $this->privateTempStore = $temp_store_factory->get('group_menu_add_temp');
   }
 
@@ -43,7 +46,6 @@ MenuLinkTreeInterface $menu_tree, LinkGeneratorInterface $link_generator, Privat
    */
   public static function create(ContainerInterface $container) {
     return new static (
-      $container->get('entity.query'),
       $container->get('plugin.manager.menu.link'),
       $container->get('menu.link_tree'),
       $container->get('link_generator'),


### PR DESCRIPTION
I started working with core 8.3-RC1 and creating a new menu didn't work. This change then sets the required core version to 8.3.  I'm not familiar with Drupal best practices to support prior versions, if that's even a concern.

8.3 Compatibility: Remove 'QueryFactory $entity_query_factory' as param on MenuForm constructor

Change Record: entity.query service deprecated in favor of EntityStorageInterface::getQuery()
https://www.drupal.org/node/2849874
http://cgit.drupalcode.org/drupal/commit/?id=6018d048bbc22e0ec0bc269b9473b57b8bd0b5d5